### PR TITLE
Add BigQuery GA4 authentication flow

### DIFF
--- a/R/general_authentication.R
+++ b/R/general_authentication.R
@@ -378,8 +378,6 @@ authentication_Google_BigQuery <-  function(args) {
     # Cleanup of private key afterwards
     unlink(decrypted_file)
     print(paste0(decrypted_file, " deleted."))
-
-    return("No Key")
   })
 }
 
@@ -406,7 +404,7 @@ authentication_Google_BigQuery_GA4 <- function(args) {
   decrypted_file <-
     "../../keys/ga4_bigQuery/ga4studyflix-c43a79c8c2cb.json"
 
-  project_id <- "ga4studyflix-c43a79c8c2cb"
+  project_id <- "ga4studyflix"
 
   tryCatch({
     safer::decrypt_file(
@@ -424,21 +422,8 @@ authentication_Google_BigQuery_GA4 <- function(args) {
     bigrquery::bq_auth(token = googleAuthR::gar_token())
 
     # Verify authentication
-    tryCatch(
-      {
-        bigrquery::bq_project_datasets(project_id)
-        message("Authentication successful — connected to '", project_id, "'.")
-      },
-      error = function(e) {
-        stop(
-          "Authentication failed. Check that '",
-          encrypted_file,
-          "' exists and the service account has BigQuery permissions.\n",
-          "Original error: ",
-          conditionMessage(e)
-        )
-      }
-    )
+    bigrquery::bq_project_datasets(project_id)
+    message("Authentication successful — connected to '", project_id, "'.")
   },
   error = function(e) {
     cat("An error occurred: ", e$message, "\n")
@@ -448,8 +433,6 @@ authentication_Google_BigQuery_GA4 <- function(args) {
     # Cleanup of decrypted key file
     unlink(decrypted_file)
     print(paste0(decrypted_file, " deleted."))
-
-    return("No Key")
   })
 }
 

--- a/R/general_authentication.R
+++ b/R/general_authentication.R
@@ -39,7 +39,7 @@ library(googleAuthR)
 #' authentication_process(needed_services = c("postgresql"), args = args)
 #' }
 #' @export
-authentication_process <- function(needed_services = c("billomat", "crm", "crm_lm", "google sheet","asana", "msgraph", "brevo", "google analytics", "bonusDB", "BigQuery", "cleverreach", "postgresql", "gemini", "openrouter", "personio"), args) {
+authentication_process <- function(needed_services = c("billomat", "crm", "crm_lm", "google sheet","asana", "msgraph", "brevo", "google analytics", "bonusDB", "BigQuery", "BigQuery GA4", "cleverreach", "postgresql", "gemini", "openrouter", "personio"), args) {
 
   auth_functions <- list(
     billomat = authentication_billomat,
@@ -52,6 +52,7 @@ authentication_process <- function(needed_services = c("billomat", "crm", "crm_l
     `google analytics` = authentication_Google_Analytics,
     bonusDB = authentication_bonus_db,
     BigQuery = authentication_Google_BigQuery,
+    `BigQuery GA4` = authentication_Google_BigQuery_GA4,
     cleverreach = authentication_cleverreach,
     postgresql = authentication_postgresql,
     gemini = authentication_gemini,
@@ -375,6 +376,76 @@ authentication_Google_BigQuery <-  function(args) {
   },
   finally = {
     # Cleanup of private key afterwards
+    unlink(decrypted_file)
+    print(paste0(decrypted_file, " deleted."))
+
+    return("No Key")
+  })
+}
+
+#' authentication_Google_BigQuery_GA4
+#'
+#' This function executes the GA4 BigQuery authentication process for the
+#' bigquery@ga4studyflix.iam.gserviceaccount.com service account.
+#' It decrypts the encrypted key file, authenticates via googleAuthR and bigrquery,
+#' verifies the connection, and deletes the decrypted file afterwards.
+#' It can handle manual password inputs as well as Flow Force args Inputs.
+
+#' @param args Additional Input Parameter, only needed through FlowForce Job
+#' @return no return values
+authentication_Google_BigQuery_GA4 <- function(args) {
+  if (interactive() & (length(args) == 0 | is.na(args[1]))) {
+    decrypt_key <-
+      getPass::getPass("Enter the password for BigQuery GA4: ")
+  } else {
+    decrypt_key <- args
+  }
+
+  encrypted_file <-
+    "../../keys/ga4_bigQuery/encrypted_ga4_bigquery.bin"
+  decrypted_file <-
+    "../../keys/ga4_bigQuery/ga4studyflix-c43a79c8c2cb.json"
+
+  project_id <- "ga4studyflix-c43a79c8c2cb"
+
+  tryCatch({
+    safer::decrypt_file(
+      infile  = encrypted_file,
+      key     = decrypt_key,
+      outfile = decrypted_file
+    )
+    print("Decryption successful. Data saved to ga4studyflix-c43a79c8c2cb.json")
+
+    # Authenticate with GA4 BigQuery service account
+    googleAuthR::gar_auth_service(
+      json_file = decrypted_file,
+      scope     = "https://www.googleapis.com/auth/bigquery"
+    )
+    bigrquery::bq_auth(token = googleAuthR::gar_token())
+
+    # Verify authentication
+    tryCatch(
+      {
+        bigrquery::bq_project_datasets(project_id)
+        message("Authentication successful — connected to '", project_id, "'.")
+      },
+      error = function(e) {
+        stop(
+          "Authentication failed. Check that '",
+          encrypted_file,
+          "' exists and the service account has BigQuery permissions.\n",
+          "Original error: ",
+          conditionMessage(e)
+        )
+      }
+    )
+  },
+  error = function(e) {
+    cat("An error occurred: ", e$message, "\n")
+    print("Please check also if you have ../../keys/ga4_bigQuery/encrypted_ga4_bigquery.bin")
+  },
+  finally = {
+    # Cleanup of decrypted key file
     unlink(decrypted_file)
     print(paste0(decrypted_file, " deleted."))
 


### PR DESCRIPTION
Introduce a new 'BigQuery GA4' service and wire it into the authentication dispatcher. Implement authentication_Google_BigQuery_GA4 which decrypts an encrypted GA4 BigQuery service-account key (supports interactive getPass or args), authenticates via googleAuthR and bigrquery, verifies access to the GA4 project, and cleans up the decrypted key file. Includes error handling and status messages.