### PR TITLE
Support group_id in update_crm_company

### DIFF
--- a/R/crm_api_companies.R
+++ b/R/crm_api_companies.R
@@ -267,6 +267,7 @@ create_crm_company <- function(headers, df) {
 #'  action - has to be value "update"
 #'  field_type - has to be value "company"
 #'  name - optional (company name)
+#'  group_id - optional (group assignment in CRM)
 #'
 #' @param headers the header informations you have to send with your request
 #' @param df the dataframe which should include the following fields:
@@ -293,6 +294,9 @@ update_crm_company <- function(headers, df) {
     # Add optional fields only if they exist and are not NA/empty
     if (has_valid_value(df, "name", p)) {
       company_data$company$name <- df$name[p]
+    }
+    if (has_valid_value(df, "group_id", p)) {
+      company_data$company$group_id <- df$group_id[p]
     }
 
     # Check if we have any updates


### PR DESCRIPTION
## Summary
- `update_crm_company()` sendet jetzt `company.group_id` im PUT-Body, wenn vorhanden (1:1 wie `update_crm_person()`).

## Changes
### Modified
- `R/crm_api_companies.R` - additiver `group_id`-Block + roxygen (`+4` Zeilen).

## Technical notes
- **Additiv & optional:** bestehende Aufrufer (nur `name`) bleiben unveraendert.
- Ermoeglicht das Verschieben von Firmen zwischen CRM-Gruppen via API. Vorher wurde eine Zeile ohne `name` im Guard `length(company_data$company) == 0` uebersprungen - es ging gar kein Request raus.
- Konsument: base-11 `do/assign_internal_groups.R` (Firmen-Write).

## Test plan
- [ ] `update_crm_company` mit `df = {attachable_id, action="update", field_type="company", group_id=<gid>}` sendet `{"company":{"group_id":<gid>}}` im PUT-Body (vorher: uebersprungen).
- [ ] Bestehende Aufrufer (nur `name`) verhalten sich unveraendert.
- [ ] An einer Test-Firma im CRM verifizieren.

## Related
- base-11 PR: Studyflix/base-11-CRM_Tagging#25
- Asana: https://app.asana.com/1/734700742714256/project/1209075503734540/task/1214293587948101