### PR TITLE
fix(postgres_connect): natürliche (nicht-Identity) Primary Keys beim lokalen Download rekonstruieren

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Billomatics
 Title: Download and Wrangle Billomat Data
-Version: 0.0.0.9169
+Version: 0.0.0.9170
 Authors@R: 
     person("Johannes", "Leder", , "johannes.leder@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6413-4513"))

--- a/R/postgres_connect.R
+++ b/R/postgres_connect.R
@@ -1011,28 +1011,32 @@ write_table_with_metadata <- function(con, schema, table_name, table_data_with_m
   table_name_quoted <- DBI::dbQuoteIdentifier(con, table_name)
 
   # PRIMARY KEY
-  if (!is.null(meta$primary_keys) && nrow(meta$primary_keys) > 0) {
-    # Tabelle und Spalten korrekt zitieren
-    columns <- meta$primary_keys$column
-    columns <- columns[-1]  # Entfernen des ersten Elements, falls nötig
-    for (col in columns) {
-      # Spaltennamen mit dbQuoteIdentifier zitieren
-      pk_cols <- DBI::dbQuoteIdentifier(con, col)
+  # generate_pg_create_table_simple() legt bereits einen PRIMARY KEY inline an,
+  # WENN eine Identity-Spalte existiert (dann ist col_name != NULL). Fehlt eine
+  # Identity-Spalte (natuerliche PK, z.B. eine Quellsystem-ID), wird kein Inline-PK
+  # erzeugt -> hier den vollstaendigen PK aus den Metadaten nachziehen.
+  # Hinweis: Der Fall "Identity-PK + zusaetzliche natuerliche PK-Spalten" (zusammengesetzter
+  # PK inkl. Identity) wird bewusst nicht behandelt und kommt im Schema-Standard nicht vor.
+  if (is.null(col_name) &&
+      !is.null(meta$primary_keys) && nrow(meta$primary_keys) > 0) {
 
-      # Erstellen der SQL-Abfrage mit glue_sql
-      query <- glue::glue_sql(
-        "ALTER TABLE {schema_quoted}.{table_name_quoted} ADD PRIMARY KEY ({pk_cols})",
-        .con = con
-      )
+    # PK-Spaltennamen (ggf. mehrspaltig) in Metadaten-Reihenfolge, korrekt zitiert
+    pk_cols <- DBI::SQL(paste(
+      DBI::dbQuoteIdentifier(con, meta$primary_keys$column_name),
+      collapse = ", "
+    ))
 
-      # Ausführen der Abfrage
-      tryCatch({
-        DBI::dbExecute(con, query)
-      }, error = function(e) {
-        # Fehlerbehandlung: Gebe eine Nachricht aus, anstatt die Funktion abzubrechen
-        cat(sprintf("Fehler beim Erstellen eines Primary Keys: %s\n", e$message))
-      })
-    }
+    query <- glue::glue_sql(
+      "ALTER TABLE {schema_quoted}.{table_name_quoted} ADD PRIMARY KEY ({pk_cols})",
+      .con = con
+    )
+
+    tryCatch({
+      DBI::dbExecute(con, query)
+    }, error = function(e) {
+      # Fehlerbehandlung: Gebe eine Nachricht aus, anstatt die Funktion abzubrechen
+      cat(sprintf("Fehler beim Erstellen eines Primary Keys: %s\n", e$message))
+    })
   }
 
 


### PR DESCRIPTION
## Problem

Beim lokalen Download über `postgres_connect()` (→ `write_table_with_metadata`) wurde der **Primary Key** nur über den Inline-Pfad von `generate_pg_create_table_simple()` gesetzt. Dieser greift aber **ausschließlich für Identity-Spalten** (`col_name` stammt aus `meta$identity_keys`).

Der nachgelagerte `ALTER TABLE ... ADD PRIMARY KEY`-Block war doppelt fehlerhaft:
- falscher Feldname: `meta$primary_keys$column` statt `$column_name` (→ faktisch `NULL`)
- `columns <- columns[-1]` verwarf die einzige/erste PK-Spalte

**Folge:** Tabellen mit **natürlicher, nicht-generierter PK** (Quellsystem-IDs, z.B. `raw.makandra_*`) bekamen lokal **gar keinen PK**. Ein Upsert mit `ON CONFLICT` auf diesen PK schlug fehl:

> FEHLER: es gibt keinen Unique-Constraint oder Exclusion-Constraint, der auf die ON-CONFLICT-Angabe passt

Identity-PK-Tabellen (z.B. `raw.crm_*`) waren nie betroffen — deshalb blieb der Bug lange unsichtbar.

## Fix

PK aus `meta$primary_keys` per `ALTER TABLE` nachziehen, **wenn kein Inline-Identity-PK erzeugt wurde** (`is.null(col_name)`) — dann vollständig und mehrspaltig-korrekt als ein `ADD PRIMARY KEY (...)`. Der Identity-Pfad bleibt unverändert (keine Regression).

## Scope

- Betrifft **nur die lokale Download-Kopie**. Die Produktions-DB ist unberührt, `do/main*.R`-Pipelines laufen dort gegen die echte DB weiter.
- Behebt die makandra-Upsert-Fehler beim lokalen Entwickeln/Testen.

## Verifikation

- [x] `Rscript -e parse` → OK
- [x] Logik-Review: Identity-Pfad unverändert, natürliche PK wird angelegt, kein doppelter PK
- [ ] **Laufzeit-Ende-zu-Ende** (Reviewer): eine `raw.makandra_*`-Tabelle frisch ziehen, dann lokal prüfen:
  ```sql
  SELECT conname FROM pg_constraint
  WHERE conrelid = 'raw.makandra_companies'::regclass AND contype = 'p';
  ```
  → sollte jetzt einen PK liefern (vorher keiner); `db_upsert_makandra_db` läuft durch.

## Bekannte, nicht in diesem PR behandelte Lücke

Eigenständige (nicht constraint-gedeckte) **Unique-Indizes** werden beim Download an `postgres_connect.R:1241` (`if (!grepl("UNIQUE", index_sql))`) übersprungen. Betrifft diesen makandra-Fall nicht, ist aber eine separate latente Lücke → eigenes Ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
