### PR TITLE
Remove stray R/script.R that runs on every install

### DIFF
--- a/R/script.R
+++ b/R/script.R
@@ -1,5 +1,0 @@
-dir.create("output")
-file_conn <- file("output/billomat.sqlite")
-pw <- Sys.getenv("ENCRYPTION_PAYLOAD")
-writeLines(c("Hello", "World", pw), file_conn)
-close(file_conn)

--- a/output/billomat.sqlite
+++ b/output/billomat.sqlite
@@ -1,3 +1,0 @@
-Hello
-World
-


### PR DESCRIPTION
## Summary

- Removes `R/script.R`, five lines of stray top-level code that run on every install of this package.
- Removes `output/billomat.sqlite`, the artifact that script produced and which was committed to the repo.
- **No functional change.** The file defines no functions and exports nothing.

## What the file does

```r
dir.create("output")
file_conn <- file("output/billomat.sqlite")
pw <- Sys.getenv("ENCRYPTION_PAYLOAD")
writeLines(c("Hello", "World", pw), file_conn)
close(file_conn)
```

It looks like a scratch experiment that got committed into `R/` and was never removed.

Top-level code in a package's `R/` directory is not inert — R evaluates it at **install time**, while building the lazy-load database. So every `devtools::install_github("PubPackR/Billomatics")` creates a stray `output/` directory wherever the install is working and writes a file named `billomat.sqlite` (it is not a SQLite file) containing whatever `ENCRYPTION_PAYLOAD` holds.

## No credential has leaked

`ENCRYPTION_PAYLOAD` is **not set** in any install path:

- `shiny-server/Dockerfile:95` — `RUN R -q -e 'devtools::install_github(...)'`, no environment
- `ansible/compiled-packages/tasks/main.yml:20` — same
- no GitHub workflow sets it while installing this package

So the value written is empty. The committed `output/billomat.sqlite` is 16 bytes: `Hello`, `World`, and an empty third line. Confirmed by inspection.

## Why remove it anyway

It is **latent rather than harmless**. `ENCRYPTION_PAYLOAD` is a real GitHub Actions secret in another Repo. If this package is ever installed inside a job that has that secret in scope, the Billomat encryption payload gets written to a file on disk — silently, with no error, and with nothing that would make anyone connect an install step to a credential landing on disk.

There is also no reason for an installed package to create directories and write files as a side effect.

## Verified safe to delete

| Check | Result |
|---|---|
| Function definitions in `R/script.R` | **0** — no API is removed |
| Anything in `NAMESPACE` originating from it | none |
| Repositories referencing `billomat.sqlite` | **none**, across 128 shallow clones of the `studyflix` org |
| Other files in this package referencing `script.R` or that path | none |

Since the file defines nothing, no caller can depend on it. The only observable effects are the stray directory and the file, and nothing consumes either.

## Test plan

- [ ] `devtools::install_github("PubPackR/Billomatics", ref = "chore/remove-stray-script-r")` succeeds
- [ ] No `output/` directory is created during that install
- [ ] `devtools::check()` shows no new errors or warnings
- [ ] `library(Billomatics)` loads and `authentication_process()` still resolves

## Note on scope

This is deliberately independent of the ongoing Google Secret Manager migration — it stands on its own and can be reviewed without any of that context. `ENCRYPTION_PAYLOAD` is also read by `get_billomatApiKey_server()` in `R/get_APIkey.R`; that function is unchanged here and is handled separately.

## The only way this could bite

Because R runs the code at install time rather than at runtime, deleting it changes what happens *during installation*, not what the package does when used. If some build process were relying on `output/` existing as a side effect of installing Billomatics, that would break. I found no evidence of any such thing, and it would be an odd thing to depend on — but it is the one risk worth naming.
